### PR TITLE
avoid CatalogType::TABLE_MACRO_ENTRY which can cause SIGABRT

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -14,9 +14,9 @@ concurrency:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v0.10.3
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.0.0
     with:
-      duckdb_version: v0.10.3
+      duckdb_version: main
       extension_name: sqlsmith
 
   duckdb-stable-deploy:
@@ -25,6 +25,6 @@ jobs:
     uses: ./.github/workflows/_extension_deploy.yml
     secrets: inherit
     with:
-      duckdb_version: v0.10.3
+      duckdb_version: main
       extension_name: sqlsmith
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/src/statement_generator.cpp
+++ b/src/statement_generator.cpp
@@ -525,7 +525,7 @@ unique_ptr<TableRef> StatementGenerator::GenerateTableFunctionRef() {
 		if (random_val == original_val) {
 			throw InternalException("No table_functions to test.");
 		}
-		table_function_ref = &generator_context->table_functions[RandomValue(original_val)];
+		table_function_ref = &generator_context->table_functions[random_val];
 	}
 	auto &entry = table_function_ref->get().Cast<TableFunctionCatalogEntry>();
 	auto table_function = entry.functions.GetFunctionByOffset(RandomValue(entry.functions.Size()));

--- a/src/statement_generator.cpp
+++ b/src/statement_generator.cpp
@@ -518,9 +518,13 @@ unique_ptr<TableRef> StatementGenerator::GenerateSubqueryRef() {
 
 unique_ptr<TableRef> StatementGenerator::GenerateTableFunctionRef() {
 	auto original_val = generator_context->table_functions.size();
-	auto random_fun = RandomValue(original_val);
-	auto table_function_ref = &generator_context->table_functions[random_fun];
-	while (table_function_ref->get().type == CatalogType::TABLE_MACRO_ENTRY) {	
+	auto random_val = RandomValue(original_val);
+	auto table_function_ref = &generator_context->table_functions[random_val];
+	while (table_function_ref->get().type == CatalogType::TABLE_MACRO_ENTRY) {
+		random_val +=1 % generator_context->table_functions.size();
+		if (random_val == original_val) {
+			throw InternalException("No table_functions to test.");
+		}
 		table_function_ref = &generator_context->table_functions[RandomValue(original_val)];
 	}
 	auto &entry = table_function_ref->get().Cast<TableFunctionCatalogEntry>();

--- a/src/statement_generator.cpp
+++ b/src/statement_generator.cpp
@@ -517,9 +517,13 @@ unique_ptr<TableRef> StatementGenerator::GenerateSubqueryRef() {
 }
 
 unique_ptr<TableRef> StatementGenerator::GenerateTableFunctionRef() {
-	auto function = make_uniq<TableFunctionRef>();
-	auto &table_function_ref = Choose(generator_context->table_functions);
-	auto &entry = table_function_ref.get().Cast<TableFunctionCatalogEntry>();
+	auto original_val = generator_context->table_functions.size();
+	auto random_fun = RandomValue(original_val);
+	auto table_function_ref = &generator_context->table_functions[random_fun];
+	while (table_function_ref->get().type == CatalogType::TABLE_MACRO_ENTRY) {	
+		table_function_ref = &generator_context->table_functions[RandomValue(original_val)];
+	}
+	auto &entry = table_function_ref->get().Cast<TableFunctionCatalogEntry>();
 	auto table_function = entry.functions.GetFunctionByOffset(RandomValue(entry.functions.Size()));
 
 	auto result = make_uniq<TableFunctionRef>();

--- a/src/statement_generator.cpp
+++ b/src/statement_generator.cpp
@@ -517,11 +517,13 @@ unique_ptr<TableRef> StatementGenerator::GenerateSubqueryRef() {
 }
 
 unique_ptr<TableRef> StatementGenerator::GenerateTableFunctionRef() {
-	auto original_val = generator_context->table_functions.size();
-	auto random_val = RandomValue(original_val);
+	auto num_table_functions = generator_context->table_functions.size();
+	auto random_val = RandomValue(num_table_functions);
+	auto original_val = random_val;
 	auto table_function_ref = &generator_context->table_functions[random_val];
 	while (table_function_ref->get().type == CatalogType::TABLE_MACRO_ENTRY) {
-		random_val += 1 % original_val;
+		random_val += 1;
+		random_val %= num_table_functions;
 		if (random_val == original_val) {
 			throw InternalException("No table_functions to test.");
 		}

--- a/src/statement_generator.cpp
+++ b/src/statement_generator.cpp
@@ -521,7 +521,7 @@ unique_ptr<TableRef> StatementGenerator::GenerateTableFunctionRef() {
 	auto random_val = RandomValue(original_val);
 	auto table_function_ref = &generator_context->table_functions[random_val];
 	while (table_function_ref->get().type == CatalogType::TABLE_MACRO_ENTRY) {
-		random_val +=1 % generator_context->table_functions.size();
+		random_val += 1 % original_val;
 		if (random_val == original_val) {
 			throw InternalException("No table_functions to test.");
 		}


### PR DESCRIPTION
StatementGenerator::GetDatabaseState() recognises the `CatalogType::TABLE_MACRO_ENTRY` as a `table_functions` according to the `CatalogSet &DuckSchemaEntry::GetCatalogSet(CatalogType type)`. 

During a discussion with @Tmonster it was decided to avoid `CatalogType::TABLE_MACRO_ENTRY` in the Statement Generator.