### PR TITLE
Delete statement

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -30,3 +30,11 @@ jobs:
       extension_name: sqlsmith
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+
+  duckdb-main-build:
+    name: Build extension binaries
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.0.0
+    with:
+      duckdb_version: main
+      extension_name: sqlsmith
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -16,9 +16,8 @@ jobs:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.0.0
     with:
-      duckdb_version: v1.0.0
+      duckdb_version: main
       extension_name: sqlsmith
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
 
   duckdb-stable-deploy:
     name: Deploy extension binaries
@@ -26,15 +25,6 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.0.0
     secrets: inherit
     with:
-      duckdb_version: v1.0.0
-      extension_name: sqlsmith
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
-      deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
-
-  duckdb-main-build:
-    name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.0.0
-    with:
       duckdb_version: main
       extension_name: sqlsmith
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
+      deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/src/include/statement_generator.hpp
+++ b/src/include/statement_generator.hpp
@@ -58,16 +58,18 @@ public:
 	unique_ptr<SQLStatement> GenerateStatement(StatementType type); // came from private
 
 private:
-	unique_ptr<MultiStatement> GenerateAttachUse();
-	unique_ptr<SetStatement> GenerateSet();
 	unique_ptr<AttachStatement> GenerateAttach();
-	unique_ptr<DetachStatement> GenerateDetach();
-	unique_ptr<SelectStatement> GenerateSelect();
 	unique_ptr<CreateStatement> GenerateCreate();
+	unique_ptr<DeleteStatement> GenerateDelete();
+	unique_ptr<DetachStatement> GenerateDetach();
+	unique_ptr<MultiStatement> GenerateAttachUse();
+	unique_ptr<SelectStatement> GenerateSelect();
+	unique_ptr<SetStatement> GenerateSet();
+
 	unique_ptr<QueryNode> GenerateQueryNode();
 
-	unique_ptr<CreateInfo> GenerateCreateInfo();
 	unique_ptr<AttachInfo> GenerateAttachInfo();
+	unique_ptr<CreateInfo> GenerateCreateInfo();
 	unique_ptr<DetachInfo> GenerateDetachInfo();
 
 	void GenerateCTEs(QueryNode &node);

--- a/src/statement_generator.cpp
+++ b/src/statement_generator.cpp
@@ -125,6 +125,8 @@ unique_ptr<SQLStatement> StatementGenerator::GenerateStatement(StatementType typ
 	// generate USE statement
 	case StatementType::SET_STATEMENT:
 		return GenerateSet();
+	case StatementType::DELETE_STATEMENT:
+		return GenerateDelete();
 	default:
 		throw InternalException("Unsupported type");
 	}
@@ -173,6 +175,12 @@ unique_ptr<MultiStatement> StatementGenerator::GenerateAttachUse() {
 	multi_statement->statements.push_back(std::move(GenerateAttach()));
 	multi_statement->statements.push_back(std::move(GenerateSet()));
 	return multi_statement;
+}
+
+unique_ptr<DeleteStatement> StatementGenerator::GenerateDelete() {
+	auto delete_statement = make_uniq<DeleteStatement>();
+	delete_statement->table = GenerateTableRef();
+	return delete_statement;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/statement_generator.cpp
+++ b/src/statement_generator.cpp
@@ -93,22 +93,22 @@ std::shared_ptr<GeneratorContext> StatementGenerator::GetDatabaseState(ClientCon
 }
 
 unique_ptr<SQLStatement> StatementGenerator::GenerateStatement() {
-	// if (RandomPercentage(80)) {
-	// 	return GenerateStatement(StatementType::SELECT_STATEMENT);
-	// }
-	// if (RandomPercentage(40)) {
-	// 	if (RandomPercentage(50)) {
-	// 		// We call this directly so we have a higher chance to fuzz persistent databases
-	// 		return GenerateAttachUse();
-	// 	}
-	// 	return GenerateStatement(StatementType::ATTACH_STATEMENT);
-	// }
-	// if (RandomPercentage(60)) {
-	// 	return GenerateStatement(StatementType::DETACH_STATEMENT);
-	// }
-	// if (RandomPercentage(30)) {
-	// 	return GenerateStatement(StatementType::SET_STATEMENT);
-	// }
+	if (RandomPercentage(80)) {
+		return GenerateStatement(StatementType::SELECT_STATEMENT);
+	}
+	if (RandomPercentage(40)) {
+		if (RandomPercentage(50)) {
+			// We call this directly so we have a higher chance to fuzz persistent databases
+			return GenerateAttachUse();
+		}
+		return GenerateStatement(StatementType::ATTACH_STATEMENT);
+	}
+	if (RandomPercentage(60)) {
+		return GenerateStatement(StatementType::DETACH_STATEMENT);
+	}
+	if (RandomPercentage(30)) {
+		return GenerateStatement(StatementType::SET_STATEMENT);
+	}
 	if (RandomPercentage(40)) { //20
 		return GenerateStatement(StatementType::DELETE_STATEMENT);
 	}
@@ -187,11 +187,11 @@ unique_ptr<DeleteStatement> StatementGenerator::GenerateDelete() {
 		auto &entry_ref = Choose(generator_context->tables_and_views);
 		auto &entry = entry_ref.get();
 		if (entry.type == CatalogType::TABLE_ENTRY) {
-		auto result = make_uniq<BaseTableRef>();
+			auto result = make_uniq<BaseTableRef>();
 			result->table_name = entry.name;
 			delete_statement->table = std::move(result);
 		} else {
-		delete_statement->table = GenerateTableRef();
+			delete_statement->table = GenerateTableRef();
 		}
 	} else {
 		delete_statement->table = GenerateTableRef();

--- a/src/statement_generator.cpp
+++ b/src/statement_generator.cpp
@@ -93,23 +93,23 @@ std::shared_ptr<GeneratorContext> StatementGenerator::GetDatabaseState(ClientCon
 }
 
 unique_ptr<SQLStatement> StatementGenerator::GenerateStatement() {
-	if (RandomPercentage(80)) {
-		return GenerateStatement(StatementType::SELECT_STATEMENT);
-	}
-	if (RandomPercentage(40)) {
-		if (RandomPercentage(50)) {
-			// We call this directly so we have a higher chance to fuzz persistent databases
-			return GenerateAttachUse();
-		}
-		return GenerateStatement(StatementType::ATTACH_STATEMENT);
-	}
-	if (RandomPercentage(60)) {
-		return GenerateStatement(StatementType::DETACH_STATEMENT);
-	}
-	if (RandomPercentage(30)) {
-		return GenerateStatement(StatementType::SET_STATEMENT);
-	}
-	if (RandomPercentage(20)) {
+	// if (RandomPercentage(80)) {
+	// 	return GenerateStatement(StatementType::SELECT_STATEMENT);
+	// }
+	// if (RandomPercentage(40)) {
+	// 	if (RandomPercentage(50)) {
+	// 		// We call this directly so we have a higher chance to fuzz persistent databases
+	// 		return GenerateAttachUse();
+	// 	}
+	// 	return GenerateStatement(StatementType::ATTACH_STATEMENT);
+	// }
+	// if (RandomPercentage(60)) {
+	// 	return GenerateStatement(StatementType::DETACH_STATEMENT);
+	// }
+	// if (RandomPercentage(30)) {
+	// 	return GenerateStatement(StatementType::SET_STATEMENT);
+	// }
+	if (RandomPercentage(40)) { //20
 		return GenerateStatement(StatementType::DELETE_STATEMENT);
 	}
 	return GenerateStatement(StatementType::CREATE_STATEMENT);
@@ -182,7 +182,21 @@ unique_ptr<MultiStatement> StatementGenerator::GenerateAttachUse() {
 
 unique_ptr<DeleteStatement> StatementGenerator::GenerateDelete() {
 	auto delete_statement = make_uniq<DeleteStatement>();
-	delete_statement->table = GenerateTableRef();
+	auto state = GetDatabaseState(context);
+	if (!generator_context->tables_and_views.empty()) {
+		auto &entry_ref = Choose(generator_context->tables_and_views);
+		auto &entry = entry_ref.get();
+		if (entry.type == CatalogType::TABLE_ENTRY) {
+		auto result = make_uniq<BaseTableRef>();
+			result->table_name = entry.name;
+			delete_statement->table = std::move(result);
+		} else {
+		delete_statement->table = GenerateTableRef();
+		}
+	} else {
+		delete_statement->table = GenerateTableRef();
+	}
+	
 	return delete_statement;
 }
 

--- a/src/statement_generator.cpp
+++ b/src/statement_generator.cpp
@@ -109,6 +109,9 @@ unique_ptr<SQLStatement> StatementGenerator::GenerateStatement() {
 	if (RandomPercentage(30)) {
 		return GenerateStatement(StatementType::SET_STATEMENT);
 	}
+	if (RandomPercentage(20)) {
+		return GenerateStatement(StatementType::DELETE_STATEMENT);
+	}
 	return GenerateStatement(StatementType::CREATE_STATEMENT);
 }
 


### PR DESCRIPTION
This PR adds GenerateDelete() to Statement Generator.
This function generates the DELETE_STATEMENT for one of the tables from the context or based on the randomly generated table references. 

What's more, this PR removes `.github/workflows/_extension_deploy.yml` file and updates `.github/workflows/MainDistributionPipeline.yml` to use the `_extension_deploy.yml` from the `extension-ci-tools` instead of a local copy, as @samansmink recommended to do. Also the `wasm_mvp;wasm_eh;wasm_threads and windows_amd64_rtools` are skipped for now.