### PR TITLE
added two more jobs to build and deploy main version

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -30,3 +30,22 @@ jobs:
       extension_name: sqlsmith
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+
+  duckdb-main-build:
+    name: Build extension binaries
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.0.0
+    with:
+      duckdb_version: main
+      extension_name: sqlsmith
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
+
+  duckdb-main-deploy:
+    name: Deploy extension binaries
+    needs: duckdb-stable-build
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.0.0
+    secrets: inherit
+    with:
+      duckdb_version: main
+      extension_name: sqlsmith
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
+      deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
This PR adds two jobs MainDistributionPipeline.yml as @carlopi suggested [here](https://github.com/duckdb/duckdb_sqlsmith/pull/11#discussion_r1672344984)