### PR TITLE
build against v1.0.0 in the MainDistributionPipeline

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.0.0
     with:
-      duckdb_version: main
+      duckdb_version: v1.0.0
       extension_name: sqlsmith
 
   duckdb-stable-deploy:
@@ -25,6 +25,6 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.0.0
     secrets: inherit
     with:
-      duckdb_version: main
+      duckdb_version: v1.0.0
       extension_name: sqlsmith
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
This tiny PR changed the `duckdb_version` to `v1.0.0` because the current main version has some CI failing changes.

We will align with the current main before updating `duckdb` submodule version to the next one.