### PR TITLE
Reuse external workflows in Fuzzer CI

### DIFF
--- a/.github/workflows/test-fuzzer-ci-still-works.yml
+++ b/.github/workflows/test-fuzzer-ci-still-works.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-duckdb:
     name: Build DuckDB
-    uses: duckdb/duckdb-fuzzer-ci/.github/workflows/reusable_build.yml@reusable-workflows-for-fuzzer-ci
+    uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/reusable_build.yml@reusable-workflows-for-fuzzer-ci
     with:
       git_url: ${{ github.actor }}
       git_tag: ${{ github.ref_name }}
@@ -25,7 +25,7 @@ jobs:
       matrix:
         fuzzer: [duckfuzz, sqlsmith, duckfuzz_functions]
         data: [emptyalltypes]
-    uses: duckdb/duckdb-fuzzer-ci/.github/workflows/reusable_fuzzer.yml@reusable-workflows-for-fuzzer-ci
+    uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/reusable_fuzzer.yml@reusable-workflows-for-fuzzer-ci
     with:
       fuzzer: ${{ matrix.fuzzer }}
       data: ${{ matrix.data }}

--- a/.github/workflows/test-fuzzer-ci-still-works.yml
+++ b/.github/workflows/test-fuzzer-ci-still-works.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build-duckdb:
     name: Build DuckDB
+    # should be a valid tag, branch name or commit. After it gets merged, we can replace it with the branch name
     uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/reusable_build.yml@a718b91bfe729290ad0525722cd77651416d2046
     with:
       git_url: ${{ github.actor }}
@@ -30,5 +31,5 @@ jobs:
       fuzzer: ${{ matrix.fuzzer }}
       data: ${{ matrix.data }}
       timeout-minutes: 20
-      dry: dry
+      dry: --dry
       max_queries: 10

--- a/.github/workflows/test-fuzzer-ci-still-works.yml
+++ b/.github/workflows/test-fuzzer-ci-still-works.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-duckdb:
     name: Build DuckDB
-    uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/build_fuzzer.yml@main
+    uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/reusable_workflows/build_fuzzer.yml@main
     with:
       git_url: ${{ github.actor }}
       git_tag: ${{ github.ref_name }}
@@ -31,7 +31,7 @@ jobs:
             fuzzer: sqlsmith
           - enable_verification: true
             fuzzer: duckfuzz_functions
-    uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/fuzz_duckdb.yml@main
+    uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/reusable_workflows/fuzz_duckdb.yml@main
     with:
       fuzzer: ${{ matrix.fuzzer }}
       data: ${{ matrix.data }}

--- a/.github/workflows/test-fuzzer-ci-still-works.yml
+++ b/.github/workflows/test-fuzzer-ci-still-works.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-duckdb:
     name: Build DuckDB
-    uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/reusable_build.yml@reusable-workflows-for-fuzzer-ci
+    uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/reusable_build.yml@a718b91bfe729290ad0525722cd77651416d2046
     with:
       git_url: ${{ github.actor }}
       git_tag: ${{ github.ref_name }}
@@ -25,7 +25,7 @@ jobs:
       matrix:
         fuzzer: [duckfuzz, sqlsmith, duckfuzz_functions]
         data: [emptyalltypes]
-    uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/reusable_fuzzer.yml@reusable-workflows-for-fuzzer-ci
+    uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/reusable_fuzzer.yml@a718b91bfe729290ad0525722cd77651416d2046
     with:
       fuzzer: ${{ matrix.fuzzer }}
       data: ${{ matrix.data }}

--- a/.github/workflows/test-fuzzer-ci-still-works.yml
+++ b/.github/workflows/test-fuzzer-ci-still-works.yml
@@ -37,5 +37,4 @@ jobs:
       data: ${{ matrix.data }}
       timeout-minutes: 20
       max_queries: 10
-      dry: false
       enable_verification: ${{ matrix.enable_verification }}

--- a/.github/workflows/test-fuzzer-ci-still-works.yml
+++ b/.github/workflows/test-fuzzer-ci-still-works.yml
@@ -31,5 +31,4 @@ jobs:
       fuzzer: ${{ matrix.fuzzer }}
       data: ${{ matrix.data }}
       timeout-minutes: 20
-      dry: --dry
       max_queries: 10

--- a/.github/workflows/test-fuzzer-ci-still-works.yml
+++ b/.github/workflows/test-fuzzer-ci-still-works.yml
@@ -25,6 +25,12 @@ jobs:
       matrix:
         fuzzer: [duckfuzz, sqlsmith, duckfuzz_functions]
         data: [emptyalltypes]
+        enable_verification: [true, false]
+        exclude:
+          - enable_verification: true
+            fuzzer: sqlsmith
+          - enable_verification: true
+            fuzzer: duckfuzz_functions
     uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/fuzz_duckdb.yml@main
     with:
       fuzzer: ${{ matrix.fuzzer }}
@@ -32,3 +38,4 @@ jobs:
       timeout-minutes: 20
       max_queries: 10
       dry: false
+      enable_verification: ${{ matrix.enable_verification }}

--- a/.github/workflows/test-fuzzer-ci-still-works.yml
+++ b/.github/workflows/test-fuzzer-ci-still-works.yml
@@ -10,88 +10,25 @@ on:
 jobs:
   build-duckdb:
     name: Build DuckDB
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    outputs:
-      duckdb-hash: ${{ steps.find-hash.outputs.hash }}
-    env:
-      BUILD_ICU: 1
-      BUILD_JSON: 1
-      BUILD_TPCH: 1
-      BUILD_TPCDS: 1
-      BUILD_PARQUET: 1
-      BUILD_JEMALLOC: 1
-      CRASH_ON_ASSERT: 1
-      GEN: ninja
-
-    steps:
-      - name: Dependencies
-        shell: bash
-        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build ccache
-
-      - uses: actions/checkout@v3
-        with:
-          repository: duckdb/duckdb
-          fetch-depth: 0
-
-      - name: Setup Ccache
-        uses: hendrikmuhs/ccache-action@main
-
-      - id: find-hash
-        run: echo "::set-output name=hash::$(git rev-parse HEAD)"
-
-      - name: create build sqlsmith extension file
-        shell: bash
-        run: |
-          echo "duckdb_extension_load(sqlsmith 
-            GIT_URL https://github.com/duckdb/duckdb_sqlsmith 
-            GIT_TAG main 
-          )" > sqlsmith.cmake
-
-      - name: Build
-        shell: bash
-        run: |
-          EXTENSION_CONFIGS="sqlsmith.cmake" make debug
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: duckdb
-          path: build/debug/duckdb
+    uses: duckdb/duckdb-fuzzer-ci/.github/workflows/reusable_build.yml@reusable-workflows-for-fuzzer-ci
+    with:
+      git_url: ${{ github.actor }}
+      git_tag: ${{ github.ref_name }}
+      timeout-minutes: 120
 
   fuzzer:
     name: Fuzzer
     needs:
     - build-duckdb
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         fuzzer: [duckfuzz, sqlsmith, duckfuzz_functions]
         data: [emptyalltypes]
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          path: duckdb_sqlsmith
-          fetch-depth: 0
-
-      - name: Download a single artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: duckdb
-
-      - name: Fuzz
-        shell: bash
-        run: |
-            chmod +x duckdb
-            runtime="1 minute"
-            endtime=$(date -ud "$runtime" +%s)
-
-            cd duckdb_sqlsmith
-            while [[ $(date -u +%s) -le $endtime ]]
-            do
-                echo "Time Now: `date +%H:%M:%S`"
-                python3 scripts/run_fuzzer.py --no_checks --${{ matrix.fuzzer }} --${{ matrix.data }} --shell=../duckdb --dry --max_queries=10
-            done
-
+    uses: duckdb/duckdb-fuzzer-ci/.github/workflows/reusable_fuzzer.yml@reusable-workflows-for-fuzzer-ci
+    with:
+      fuzzer: ${{ matrix.fuzzer }}
+      data: ${{ matrix.data }}
+      timeout-minutes: 20
+      dry: dry
+      max_queries: 10

--- a/.github/workflows/test-fuzzer-ci-still-works.yml
+++ b/.github/workflows/test-fuzzer-ci-still-works.yml
@@ -10,8 +10,7 @@ on:
 jobs:
   build-duckdb:
     name: Build DuckDB
-    # should be a valid tag, branch name or commit. After it gets merged, we can replace it with the branch name
-    uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/reusable_build.yml@a718b91bfe729290ad0525722cd77651416d2046
+    uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/build_fuzzer.yml@main
     with:
       git_url: ${{ github.actor }}
       git_tag: ${{ github.ref_name }}
@@ -26,9 +25,10 @@ jobs:
       matrix:
         fuzzer: [duckfuzz, sqlsmith, duckfuzz_functions]
         data: [emptyalltypes]
-    uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/reusable_fuzzer.yml@a718b91bfe729290ad0525722cd77651416d2046
+    uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/fuzz_duckdb.yml@main
     with:
       fuzzer: ${{ matrix.fuzzer }}
       data: ${{ matrix.data }}
       timeout-minutes: 20
       max_queries: 10
+      dry: false

--- a/scripts/run_fuzzer.py
+++ b/scripts/run_fuzzer.py
@@ -40,7 +40,7 @@ for param in sys.argv:
     elif param.startswith('--max_queries='):
         max_queries = int(param.replace('--max_queries=', ''))
     elif param.startswith('--dry'):
-        dry = True
+        dry = param.replace('--dry=', '').lower() == 'true'
 
 if fuzzer is None:
     print("Unrecognized fuzzer to run, expected e.g. --sqlsmith or --duckfuzz")

--- a/scripts/run_fuzzer.py
+++ b/scripts/run_fuzzer.py
@@ -13,7 +13,7 @@ fuzzer = None
 db = None
 shell = None
 perform_checks = True
-dry = False
+no-git-checks = False
 max_queries = 1000
 verification = False
 for param in sys.argv:
@@ -39,8 +39,8 @@ for param in sys.argv:
         seed = int(param.replace('--seed=', ''))
     elif param.startswith('--max_queries='):
         max_queries = int(param.replace('--max_queries=', ''))
-    elif param.startswith('--dry'):
-        dry = param.replace('--dry=', '').lower() == 'true'
+    elif param.startswith('--no-git-checks'):
+        no-git-checks = param.replace('--no-git-checks=', '').lower() == 'true'
 
 if fuzzer is None:
     print("Unrecognized fuzzer to run, expected e.g. --sqlsmith or --duckfuzz")
@@ -103,7 +103,7 @@ def run_shell_command(cmd):
 
 # first get a list of all github issues, and check if we can still reproduce them
 
-if dry:
+if no-git-checks:
     current_errors = []
 else:
     current_errors = fuzzer_helper.extract_github_issues(shell, perform_checks)
@@ -212,5 +212,5 @@ print(f"After reducing: the below sql causes an internal error \n `{cmd}`")
 print(f"{error_msg}")
 print(f"================MARKER====================")
 
-if not dry:
+if not no-git-checks:
     fuzzer_helper.file_issue(cmd, error_msg, fuzzer_name, seed, git_hash)


### PR DESCRIPTION
This PR makes `test-fuzzer` reuse `Build DuckDB` and `Fuzzer` workflows and connected to the https://github.com/duckdb/duckdb_sqlsmith/issues/22