### PR TITLE
fix test-fuzzer-ci-still-works

### DIFF
--- a/.github/workflows/test-fuzzer-ci-still-works.yml
+++ b/.github/workflows/test-fuzzer-ci-still-works.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-duckdb:
     name: Build DuckDB
-    uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/reusable_workflows/build_fuzzer.yml@main
+    uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/build_fuzzer.yml@main
     with:
       git_url: ${{ github.actor }}
       git_tag: ${{ github.ref_name }}
@@ -31,7 +31,7 @@ jobs:
             fuzzer: sqlsmith
           - enable_verification: true
             fuzzer: duckfuzz_functions
-    uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/reusable_workflows/fuzz_duckdb.yml@main
+    uses: duckdblabs/duckdb-fuzzer-ci/.github/workflows/fuzz_duckdb.yml@main
     with:
       fuzzer: ${{ matrix.fuzzer }}
       data: ${{ matrix.data }}


### PR DESCRIPTION
There was an [issue](https://github.com/duckdb/duckdb_sqlsmith/actions/runs/10682470199/workflow) with the `test-fuzzer-ci-still-works` - CI couldn't find the reusable workflows by provided paths.
This PR sets proper paths to the `Build DuckDB` and `Fuzzer` jobs in this workflow.
