### PR TITLE
errors containing "internal_tablefilter" are not necessarily internal errors

### DIFF
--- a/scripts/fuzzer_helper.py
+++ b/scripts/fuzzer_helper.py
@@ -27,6 +27,7 @@ INTERNAL_ERROR_FALSE_POSITIVES = [
     "internal use",
     "internal_compress",
     "internal_decompress",
+    "internal_tablefilter",
 ]
 
 fuzzer_desc = '''Issue found by ${FUZZER} on git commit hash [${SHORT_HASH}](https://github.com/duckdb/duckdb/commit/${FULL_HASH}) using seed ${SEED}.


### PR DESCRIPTION
the logic to detect internal errors now searches for the word "internal" in the error message. This leads to false positives, since some function names contain the word "internal" and print it also for regular errors.

This whitelist is used to filter out these false positives