### PR TITLE
catch timeouts

### DIFF
--- a/scripts/run_fuzzer.py
+++ b/scripts/run_fuzzer.py
@@ -95,7 +95,7 @@ def get_fuzzer_name_printable(fuzzer):
         return 'Unknown'
 
 
-def run_shell_command(cmd, timeout=300):
+def run_shell_command(cmd, timeout=600):
     command = [shell, '--batch', '-init', '/dev/null']
     try:
         res = subprocess.run(command, input=bytearray(cmd, 'utf8'), stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=timeout)

--- a/scripts/run_fuzzer.py
+++ b/scripts/run_fuzzer.py
@@ -95,9 +95,12 @@ def get_fuzzer_name_printable(fuzzer):
         return 'Unknown'
 
 
-def run_shell_command(cmd):
+def run_shell_command(cmd, timeout=300):
     command = [shell, '--batch', '-init', '/dev/null']
-    res = subprocess.run(command, input=bytearray(cmd, 'utf8'), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try:
+        res = subprocess.run(command, input=bytearray(cmd, 'utf8'), stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return ("", f"query timed out after {timeout} seconds", -1)
     stdout = res.stdout.decode('utf8', 'ignore').strip()
     stderr = res.stderr.decode('utf8', 'ignore').strip()
     return (stdout, stderr, res.returncode)


### PR DESCRIPTION
Sometimes fuzzer jobs fail with error:

> The hosted runner lost communication with the server. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.

See for example: https://github.com/duckdblabs/duckdb-fuzzer-ci/actions/runs/26619814176/job/78446699949

This is likely caused by a timeout in the fuzzer sub-process. We now catch this by explicitly setting a timeout.